### PR TITLE
Fix track length variable typo

### DIFF
--- a/HepEmShow.cc
+++ b/HepEmShow.cc
@@ -137,8 +137,8 @@ int main(int argc, char* argv[]) {
        }
     }
   #endif
-  theResult.fGammaTrackLenghtPerLayer.ReSet("hist_GamTrackL_PerLayer", 0, theGeometry.GetNumLayers(), theGeometry.GetNumLayers());
-  theResult.fElPosTrackLenghtPerLayer.ReSet("hist_ElPosTrackL_PerLayer", 0, theGeometry.GetNumLayers(), theGeometry.GetNumLayers());
+  theResult.fGammaTrackLengthPerLayer.ReSet("hist_GamTrackL_PerLayer", 0, theGeometry.GetNumLayers(), theGeometry.GetNumLayers());
+  theResult.fElPosTrackLengthPerLayer.ReSet("hist_ElPosTrackL_PerLayer", 0, theGeometry.GetNumLayers(), theGeometry.GetNumLayers());
 
 
   // here we start the event processing: generate the required number of event and simulte each event.

--- a/Simulation/include/Results.hh
+++ b/Simulation/include/Results.hh
@@ -78,8 +78,8 @@ struct Results {
     Accumulator<double> barThicknessAbsorber, barThicknessGap, barParticleEnergy; ///< Accumulate the bar values of the thicknesses and energy.
     G4double pThicknessAbsorber, pThicknessGap, pParticleEnergy; ///< Copies of the thickness and energy variables used by the simulation, used as AD inputs.
   #endif
-  Hist fGammaTrackLenghtPerLayer;  ///< mean number of \f$\gamma\f$ steps per-layer histogram
-  Hist fElPosTrackLenghtPerLayer;  ///< mean number of \f$e^-/e^+\f$ steps per-layer histogram
+  Hist fGammaTrackLengthPerLayer;  ///< mean number of \f$\gamma\f$ steps per-layer histogram
+  Hist fElPosTrackLengthPerLayer;  ///< mean number of \f$e^-/e^+\f$ steps per-layer histogram
   //
   G4double fEdepAbs        { 0.0 };  ///< mean energy deposit in the `absorber`
   G4double fEdepAbs2       { 0.0 };  ///< mean of the squared energy deposit in the `absorber`

--- a/Simulation/src/Results.cc
+++ b/Simulation/src/Results.cc
@@ -13,8 +13,8 @@ void WriteResults(struct Results& res, int numEvents, int seed) {
   // for the histograms, bring them to be mean per event and write
   const G4double norm = numEvents > 0 ? 1.0/numEvents : 1.0;
   res.fEdepPerLayer.Scale(norm);
-  res.fGammaTrackLenghtPerLayer.Scale(norm);
-  res.fElPosTrackLenghtPerLayer.Scale(norm);
+  res.fGammaTrackLengthPerLayer.Scale(norm);
+  res.fElPosTrackLengthPerLayer.Scale(norm);
 
   res.fEdepPerLayer.WriteToFile(false);
   std::ofstream edeps("edeps_" + std::to_string(seed));
@@ -38,8 +38,8 @@ void WriteResults(struct Results& res, int numEvents, int seed) {
   #endif
 
 
-  res.fGammaTrackLenghtPerLayer.WriteToFile(false);
-  res.fElPosTrackLenghtPerLayer.WriteToFile(false);
+  res.fGammaTrackLengthPerLayer.WriteToFile(false);
+  res.fElPosTrackLengthPerLayer.WriteToFile(false);
 
   //
   res.fEdepAbs  = res.fEdepAbs*norm;

--- a/Simulation/src/SteppingLoop.cc
+++ b/Simulation/src/SteppingLoop.cc
@@ -334,10 +334,10 @@ void SteppingLoop::SteppingAction(Results& theResult, const G4HepEmTrack& theTra
   //
   if (currentPhysStepLength <= 0.0) return;
   if (theTrack.GetCharge() == 0.0) {
-    theResult.fGammaTrackLenghtPerLayer.Fill(indxLayer, currentPhysStepLength);
+    theResult.fGammaTrackLengthPerLayer.Fill(indxLayer, currentPhysStepLength);
     theResult.fPerEventRes.fNumStepsGamma += 1.0;
   } else {
-    theResult.fElPosTrackLenghtPerLayer.Fill(indxLayer, currentPhysStepLength);
+    theResult.fElPosTrackLengthPerLayer.Fill(indxLayer, currentPhysStepLength);
     theResult.fPerEventRes.fNumStepsElPos += 1.0;
   }
 }


### PR DESCRIPTION
## Summary
- fix typo `Lenght` -> `Length` in `Results` structures
- update references accordingly

## Testing
- `cmake ..` *(fails: missing G4HepEm)*
- `make` *(fails: no targets)*

------
https://chatgpt.com/codex/tasks/task_e_685efa5a4ce48332b67b80e541202ff1